### PR TITLE
Bug fix/make "Occasionally Attacks X" weapons work with Jump type abilities

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,76 +1,77 @@
 ﻿{
-  "configurations": [
-    {
-      "name": "x64-Release",
-      "generator": "Ninja",
-      "configurationType": "RelWithDebInfo",
-      "buildRoot": "${projectDir}\\build\\${name}",
-      "installRoot": "${projectDir}\\build\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "variables": []
-    },
-    {
-      "name": "x64-Release-Tracy",
-      "generator": "Ninja",
-      "configurationType": "RelWithDebInfo",
-      "buildRoot": "${projectDir}\\build\\${name}",
-      "installRoot": "${projectDir}\\build\\${name}",
-      "cmakeCommandArgs": "-DTRACY_ENABLE=ON",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "variables": []
-    },
-    {
-      "name": "x64-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "buildRoot": "${projectDir}\\build\\${name}",
-      "installRoot": "${projectDir}\\build\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "variables": []
-    },
-    {
-      "name": "x64-Debug-Tracy",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "buildRoot": "${projectDir}\\build\\${name}",
-      "installRoot": "${projectDir}\\build\\${name}",
-      "cmakeCommandArgs": "-DTRACY_ENABLE=ON",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "variables": []
-    },
-    {
-      "name": "x86-Release",
-      "generator": "Ninja",
-      "configurationType": "RelWithDebInfo",
-      "buildRoot": "${projectDir}\\build\\${name}",
-      "installRoot": "${projectDir}\\build\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x86" ],
-      "variables": []
-    },
-    {
-      "name": "x86-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "buildRoot": "${projectDir}\\build\\${name}",
-      "installRoot": "${projectDir}\\build\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x86" ],
-      "variables": []
-    }
-  ]
+    "configurations": [
+        {
+            "name": "x64-Release",
+            "generator": "Ninja",
+            "configurationType": "RelWithDebInfo",
+            "buildRoot": "${projectDir}\\build\\${name}",
+            "installRoot": "${projectDir}\\build\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "msvc_x64_x64" ]
+        },
+        {
+            "name": "x64-Release-Tracy",
+            "generator": "Ninja",
+            "configurationType": "RelWithDebInfo",
+            "buildRoot": "${projectDir}\\build\\${name}",
+            "installRoot": "${projectDir}\\build\\${name}",
+            "cmakeCommandArgs": "-DTRACY_ENABLE=ON",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "msvc_x64_x64" ]
+        },
+        {
+            "name": "x64-Debug",
+            "generator": "Ninja",
+            "configurationType": "Debug",
+            "buildRoot": "${projectDir}\\build\\${name}",
+            "installRoot": "${projectDir}\\build\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "variables": [
+                {
+                    "name": "WARNINGS_AS_ERRORS",
+                    "value": "False",
+                    "type": "BOOL"
+                }
+            ]
+        },
+        {
+            "name": "x64-Debug-Tracy",
+            "generator": "Ninja",
+            "configurationType": "Debug",
+            "buildRoot": "${projectDir}\\build\\${name}",
+            "installRoot": "${projectDir}\\build\\${name}",
+            "cmakeCommandArgs": "-DTRACY_ENABLE=ON",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "msvc_x64_x64" ]
+        },
+        {
+            "name": "x86-Release",
+            "generator": "Ninja",
+            "configurationType": "RelWithDebInfo",
+            "buildRoot": "${projectDir}\\build\\${name}",
+            "installRoot": "${projectDir}\\build\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "msvc_x86" ]
+        },
+        {
+            "name": "x86-Debug",
+            "generator": "Ninja",
+            "configurationType": "Debug",
+            "buildRoot": "${projectDir}\\build\\${name}",
+            "installRoot": "${projectDir}\\build\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "msvc_x86" ]
+        }
+    ]
 }

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -9,7 +9,8 @@
             "cmakeCommandArgs": "",
             "buildCommandArgs": "",
             "ctestCommandArgs": "",
-            "inheritEnvironments": [ "msvc_x64_x64" ]
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "variables": []
         },
         {
             "name": "x64-Release-Tracy",
@@ -20,7 +21,8 @@
             "cmakeCommandArgs": "-DTRACY_ENABLE=ON",
             "buildCommandArgs": "",
             "ctestCommandArgs": "",
-            "inheritEnvironments": [ "msvc_x64_x64" ]
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "variables": []
         },
         {
             "name": "x64-Debug",
@@ -32,13 +34,7 @@
             "buildCommandArgs": "",
             "ctestCommandArgs": "",
             "inheritEnvironments": [ "msvc_x64_x64" ],
-            "variables": [
-                {
-                    "name": "WARNINGS_AS_ERRORS",
-                    "value": "False",
-                    "type": "BOOL"
-                }
-            ]
+            "variables": []
         },
         {
             "name": "x64-Debug-Tracy",
@@ -49,7 +45,8 @@
             "cmakeCommandArgs": "-DTRACY_ENABLE=ON",
             "buildCommandArgs": "",
             "ctestCommandArgs": "",
-            "inheritEnvironments": [ "msvc_x64_x64" ]
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "variables": []
         },
         {
             "name": "x86-Release",
@@ -60,7 +57,8 @@
             "cmakeCommandArgs": "",
             "buildCommandArgs": "",
             "ctestCommandArgs": "",
-            "inheritEnvironments": [ "msvc_x86" ]
+            "inheritEnvironments": [ "msvc_x86" ],
+            "variables": []
         },
         {
             "name": "x86-Debug",
@@ -71,7 +69,8 @@
             "cmakeCommandArgs": "",
             "buildCommandArgs": "",
             "ctestCommandArgs": "",
-            "inheritEnvironments": [ "msvc_x86" ]
+            "inheritEnvironments": [ "msvc_x86" ],
+            "variables": []
         }
     ]
 }

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -103,7 +103,7 @@ function(set_project_warnings project_name)
     message(AUTHOR_WARNING "No compiler warnings set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
   endif()
 
-  option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
+  option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" FALSE)
   if(WARNINGS_AS_ERRORS)
     if(UNIX)
       set(ERRORS "-Werror")

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -103,7 +103,7 @@ function(set_project_warnings project_name)
     message(AUTHOR_WARNING "No compiler warnings set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
   endif()
 
-  option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" FALSE)
+  option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" TRUE)
   if(WARNINGS_AS_ERRORS)
     if(UNIX)
       set(ERRORS "-Werror")

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -46,6 +46,8 @@ local function getJumpWSParams(player, atkMultiplier, tpMultiplier, forceCrit)
         attackerTPMult = tpMultiplier,
         hitsHigh = true,
         isJump = true,
+
+        canUseOccAtkX = true,
     }
 
     if player:getMod(xi.mod.FORCE_JUMP_CRIT) > 0 or forceCrit then

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -258,7 +258,7 @@ local function getMultiAttacks(attacker, target, wsParams)
     then
         local numMainHits = attacker:getWeaponHitCount()
         -- Subtract 1 since the initial hit would have been calculated already; we just want additionals
-        utils.clamp(numMainHits - 1, 0, numMainHits)
+        numMainHits = utils.clamp(numMainHits - 1, 0, numMainHits)
 
         local numOffHits = 0
         if
@@ -267,7 +267,7 @@ local function getMultiAttacks(attacker, target, wsParams)
             numOffHits = attacker:getOffhandHitCount()
 
             -- Subtract 1 since the initial hit would have been calculated already; we just want additionals
-            utils.clamp(numOffHits - 1, 0, numOffHits)
+            numOffHits = utils.clamp(numOffHits - 1, 0, numOffHits)
         end
 
         totalOAXHits = numMainHits + numOffHits
@@ -1097,9 +1097,8 @@ xi.weaponskills.takeWeaponskillDamage = function(defender, attacker, wsParams, p
         wsResults.extraHitsLanded = 0
     end
 
-    print("tpHitsLanded = " .. tostring(wsResults.tpHitsLanded) .. ", extraHits = " .. tostring(wsResults.extraHitsLanded))
-
-    finaldmg = defender:takeWeaponskillDamage(attacker, finaldmg, attack.type, attack.damageType, attack.slot, primaryMsg, wsResults.tpHitsLanded * attackerTPMult, (wsResults.extraHitsLanded * 10) + wsResults.bonusTP, targetTPMult, attack.damageType == xi.attackType.MAGICAL)
+    finaldmg = defender:takeWeaponskillDamage(attacker, finaldmg, attack.type, attack.damageType, attack.slot, primaryMsg, wsResults.tpHitsLanded * attackerTPMult, (wsResults.extraHitsLanded * 10) + wsResults.bonusTP,
+                                              targetTPMult, attack.damageType == xi.attackType.MAGICAL, isJump)
     if wsResults.tpHitsLanded + wsResults.extraHitsLanded > 0 then
         if finaldmg >= 0 then
             action:param(defender:getID(), math.abs(finaldmg))

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -207,6 +207,7 @@ local function getMultiAttacks(attacker, target, wsParams)
     local oaThriceRate = attacker:getMod(xi.mod.MYTHIC_OCC_ATT_THRICE)
     local oaTwiceRate  = attacker:getMod(xi.mod.MYTHIC_OCC_ATT_TWICE)
     local isJump       = wsParams.isJump or false
+    local canOAX       = wsParams.canUseOccAtkX or false
 
     if isJump then
         doubleRate = doubleRate + attacker:getMod(xi.mod.JUMP_DOUBLE_ATTACK)
@@ -250,7 +251,29 @@ local function getMultiAttacks(attacker, target, wsParams)
         end
     end
 
-    numHits = utils.clamp(numHits + bonusHits, 1, 8)
+    -- If this WS/Ability is capable of multi-striking from Occasionally Attacks X weapons, calculate now
+    local totalOAXHits = 0
+    if
+        canOAX
+    then
+        local numMainHits = attacker:getWeaponHitCount()
+        -- Subtract 1 since the initial hit would have been calculated already; we just want additionals
+        utils.clamp(numMainHits - 1, 0, numMainHits)
+
+        local numOffHits = 0
+        if
+            attacker:getOffhandDmg() > 0
+        then
+            numOffHits = attacker:getOffhandHitCount()
+
+            -- Subtract 1 since the initial hit would have been calculated already; we just want additionals
+            utils.clamp(numOffHits - 1, 0, numOffHits)
+        end
+
+        totalOAXHits = numMainHits + numOffHits
+    end
+
+    numHits = utils.clamp(numHits + bonusHits + totalOAXHits, 1, 8)
 
     return numHits
 end
@@ -1070,9 +1093,11 @@ xi.weaponskills.takeWeaponskillDamage = function(defender, attacker, wsParams, p
 
     -- DA/TA/QA/OaT/Oa2-3 etc give full TP return per hit on Jumps
     if isJump then
-        attackerTPMult = attackerTPMult * (wsResults.tpHitsLanded + wsResults.extraHitsLanded)
+        wsResults.tpHitsLanded = wsResults.tpHitsLanded + wsResults.extraHitsLanded
         wsResults.extraHitsLanded = 0
     end
+
+    print("tpHitsLanded = " .. tostring(wsResults.tpHitsLanded) .. ", extraHits = " .. tostring(wsResults.extraHitsLanded))
 
     finaldmg = defender:takeWeaponskillDamage(attacker, finaldmg, attack.type, attack.damageType, attack.slot, primaryMsg, wsResults.tpHitsLanded * attackerTPMult, (wsResults.extraHitsLanded * 10) + wsResults.bonusTP, targetTPMult, attack.damageType == xi.attackType.MAGICAL)
     if wsResults.tpHitsLanded + wsResults.extraHitsLanded > 0 then

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -546,9 +546,29 @@ uint16 CBattleEntity::GetRangedWeaponRank()
     return 0;
 }
 
+uint8 CBattleEntity::GetMainWeaponHitCount()
+{
+    if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_MAIN]))
+    {
+        return weapon->getHitCount();
+    }
+
+    return 1;
+}
+
+uint8 CBattleEntity::GetSubWeaponHitCount()
+{
+    if (auto* weapon = dynamic_cast<CItemWeapon*>(m_Weapons[SLOT_SUB]))
+    {
+        return weapon->getHitCount();
+    }
+
+    return 1;
+}
+
 /************************************************************************
  *                                                                       *
- *  Изменяем количество TP сущности                                      *
+ *  Entity TP manipulation                                               *
  *                                                                       *
  ************************************************************************/
 

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -599,16 +599,18 @@ public:
     int32 GetMaxMP() const; // максимальное количество mp
     void  UpdateHealth();   // пересчет максимального количества hp и mp, а так же корректировка их текущих значений
 
-    int16  GetWeaponDelay(bool tp);       // returns delay of combined weapons
-    float  GetMeleeRange() const;         // returns the distance considered to be within melee range of the entity
-    int16  GetRangedWeaponDelay(bool tp); // returns delay of ranged weapon + ammo where applicable
-    int16  GetAmmoDelay();                // returns delay of ammo (for cooldown between shots)
-    uint16 GetMainWeaponDmg();            // returns total main hand DMG
-    uint16 GetSubWeaponDmg();             // returns total sub weapon DMG
-    uint16 GetRangedWeaponDmg();          // returns total ranged weapon DMG
-    uint16 GetMainWeaponRank();           // returns total main hand DMG Rank
-    uint16 GetSubWeaponRank();            // returns total sub weapon DMG Rank
-    uint16 GetRangedWeaponRank();         // returns total ranged weapon DMG Rank
+    int16  GetWeaponDelay(bool tp);         // returns delay of combined weapons
+    float  GetMeleeRange() const;           // returns the distance considered to be within melee range of the entity
+    int16  GetRangedWeaponDelay(bool tp);   // returns delay of ranged weapon + ammo where applicable
+    int16  GetAmmoDelay();                  // returns delay of ammo (for cooldown between shots)
+    uint16 GetMainWeaponDmg();              // returns total main hand DMG
+    uint16 GetSubWeaponDmg();               // returns total sub weapon DMG
+    uint16 GetRangedWeaponDmg();            // returns total ranged weapon DMG
+    uint16 GetMainWeaponRank();             // returns total main hand DMG Rank
+    uint16 GetSubWeaponRank();              // returns total sub weapon DMG Rank
+    uint16 GetRangedWeaponRank();           // returns total ranged weapon DMG Rank
+    uint8 GetMainWeaponHitCount();          // returns number of hits between 1 and maxHits for the main hand (for OAX)
+    uint8 GetSubWeaponHitCount();           // returns number of hits between 1 and maxHits for the off hand (for OAX)
 
     uint16 GetSkill(uint16 SkillID); // текущая величина умения (не максимальная, а ограниченная уровнем)
 

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -506,11 +506,11 @@ struct apAction_t
     }
 };
 
-/************************************************************************
- *                                                                      *
- *  TP хранится то пому же принципу, что и skill, т.е. 6,4% = 64        *
- *                                                                      *
- ************************************************************************/
+/****************************************************************************
+ *                                                                          *
+ *  TP is stored according to the same principle as skill, i.e. 6.4% = 64   *
+ *                                                                          *
+ ****************************************************************************/
 
 struct health_t
 {
@@ -622,7 +622,7 @@ public:
     virtual int32 takeDamage(int32 amount, CBattleEntity* attacker = nullptr, ATTACK_TYPE attackType = ATTACK_TYPE::NONE,
                              DAMAGE_TYPE damageType = DAMAGE_TYPE::NONE);
 
-    int16 getMod(Mod modID); // величина модификатора
+    int16 getMod(Mod modID); // Modifier value
 
     bool CanRest();        // checks if able to heal
     bool Rest(float rate); // heal an amount of hp / mp
@@ -751,14 +751,14 @@ public:
     virtual void PostTick() override;
 
     health_t health;         // hp,mp,tp
-    stats_t  stats;          // атрибуты STR,DEX,VIT,AGI,INT,MND,CHR
-    skills_t WorkingSkills;  // структура всех доступных сущности умений, ограниченных уровнем
+    stats_t  stats;          // Attributes STR,DEX,VIT,AGI,INT,MND,CHR
+    skills_t WorkingSkills;  // The structure of all available skills that are limited to a level
     uint16   m_Immunity;     // Mob immunity
-    uint16   m_magicEvasion; // store this so it can be removed easily
-    bool     m_unkillable;   // entity is not able to die (probably until some action removes this flag)
+    uint16   m_magicEvasion; // Store this so it can be removed easily
+    bool     m_unkillable;   // Entity is not able to die (probably until some action removes this flag)
 
-    time_point charmTime; // to hold the time entity is charmed
-    bool       isCharmed; // is the battle entity charmed?
+    time_point charmTime; // To hold the time entity is charmed
+    bool       isCharmed; // Is the battle entity charmed?
 
     float           m_ModelRadius; // The radius of the entity model, for calculating the range of a physical attack
     ECOSYSTEM       m_EcoSystem;   // Entity eco system
@@ -766,16 +766,16 @@ public:
     bool            m_dualWield;   // True/false depending on if the entity is using two weapons
     DEATH_TYPE      m_DeathType;
 
-    TraitList_t TraitList; // список постянно активных способностей в виде указателей
+    TraitList_t TraitList; // List of Permanently Active Abilities in the Form of Pointers
 
-    EntityID_t m_OwnerID; // ID атакующей сущности (после смерти будет хранить ID сущности, нанесщей последний удар)
+    EntityID_t m_OwnerID; // ID of the attacking entity (will store the ID of the entity that struck the last blow upon death)
 
-    ActionList_t m_ActionList; // список совершенных действий за одну атаку (нужно будет написать структуру, включающую ActionList в которой будут категории
-                               // анимации и т.д.)
+    ActionList_t m_ActionList; // A list of actions performed in one attack (you will need to write a structure that includes an ActionList
+                               // in which there will be action info, animations, etc.)
 
-    CParty*         PParty;  // описание группы, в которой состоит сущность
-    CBattleEntity*  PPet;    // питомец сущности
-    CBattleEntity*  PMaster; // владелец/хозяин сущности (распространяется на все боевые сущности)
+    CParty*         PParty;  // The Party in which the Entity is a member of
+    CBattleEntity*  PPet;    // Entity's Pet
+    CBattleEntity*  PMaster; // Entity Owner/Host (Applies to all Combat Entities)
     CBattleEntity*  PLastAttacker;
     time_point      LastAttacked;
     battlehistory_t BattleHistory; // Stores info related to most recent combat actions taken towards this entity.
@@ -789,16 +789,16 @@ public:
     std::vector<int16> m_MSNonItemValues;        // Tracking movement speed from non-item sources
 
 private:
-    JOBTYPE m_mjob; // главная профессия
-    JOBTYPE m_sjob; // дополнительная профессия
-    uint8   m_mlvl; // ТЕКУЩИЙ уровень главной профессии
-    uint8   m_slvl; // ТЕКУЩИЙ уровень дополнительной профессии
+    JOBTYPE m_mjob; // Main Job
+    JOBTYPE m_sjob; // Sub Job
+    uint8   m_mlvl; // CURRENT Main Job Level
+    uint8   m_slvl; // Current Sub Job Level
 
     uint16     m_battleTarget{ 0 };
     time_point m_battleStartTime;
     uint16     m_battleID = 0; // Current battle the entity is participating in. Battle ID must match in order for entities to interact with each other.
 
-    std::unordered_map<Mod, int16, EnumClassHash>                                                m_modStat;     // массив модификаторов
+    std::unordered_map<Mod, int16, EnumClassHash>                                                m_modStat;     // Array of modifiers
     std::unordered_map<Mod, int16, EnumClassHash>                                                m_modStatSave; // saved state
     std::unordered_map<PetModType, std::unordered_map<Mod, int16, EnumClassHash>, EnumClassHash> m_petMod;
 };

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -609,8 +609,8 @@ public:
     uint16 GetMainWeaponRank();             // returns total main hand DMG Rank
     uint16 GetSubWeaponRank();              // returns total sub weapon DMG Rank
     uint16 GetRangedWeaponRank();           // returns total ranged weapon DMG Rank
-    uint8 GetMainWeaponHitCount();          // returns number of hits between 1 and maxHits for the main hand (for OAX)
-    uint8 GetSubWeaponHitCount();           // returns number of hits between 1 and maxHits for the off hand (for OAX)
+    uint8  GetMainWeaponHitCount();         // returns number of hits between 1 and maxHits for the main hand (for OAX)
+    uint8  GetSubWeaponHitCount();          // returns number of hits between 1 and maxHits for the off hand (for OAX)
 
     uint16 GetSkill(uint16 SkillID); // текущая величина умения (не максимальная, а ограниченная уровнем)
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13022,16 +13022,14 @@ auto CLuaBaseEntity::getWSSkillchainProp() -> std::tuple<uint8, uint8, uint8>
  ************************************************************************/
 
 int32 CLuaBaseEntity::takeWeaponskillDamage(CLuaBaseEntity* attacker, int32 damage, uint8 atkType, uint8 dmgType, uint8 slot, bool primary,
-                                            float tpMultiplier, uint16 bonusTP, float targetTPMultiplier, bool isMagicWS)
+                                            float tpMultiplier, uint16 bonusTP, float targetTPMultiplier, bool isMagicWS, bool isJump)
 {
     auto*       PChar      = static_cast<CCharEntity*>(attacker->m_PBaseEntity);
     ATTACK_TYPE attackType = static_cast<ATTACK_TYPE>(atkType);
     DAMAGE_TYPE damageType = static_cast<DAMAGE_TYPE>(dmgType);
 
-    printf("TPMult = %f, BonusTP = %i\n", tpMultiplier, bonusTP );
-
     return battleutils::TakeWeaponskillDamage(PChar, static_cast<CBattleEntity*>(m_PBaseEntity), damage, attackType, damageType, slot,
-                                              primary, tpMultiplier, bonusTP, targetTPMultiplier, isMagicWS);
+                                              primary, tpMultiplier, bonusTP, targetTPMultiplier, isMagicWS, isJump);
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12843,6 +12843,32 @@ uint16 CLuaBaseEntity::getAmmoDmg()
 }
 
 /************************************************************************
+ *  Function: getWeaponHitCount()
+ *  Purpose : Gets a number of attacks between 1 and maxAttacks for the MainHand weapon (for Occasionally Attacks X weapons)
+ *  Example : player:getWeaponHitCount()
+ *  Notes   : 
+ ************************************************************************/
+uint8 CLuaBaseEntity::getWeaponHitCount()
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    return static_cast<CBattleEntity*>(m_PBaseEntity)->GetMainWeaponHitCount();
+}
+
+/************************************************************************
+ *  Function: getOffhandHitCount()
+ *  Purpose : Gets a number of attacks between 1 and maxAttacks for the OffHand weapon (for Occasionally Attacks X weapons)
+ *  Example : player:getOffhandHitCount()
+ *  Notes   : 
+ ************************************************************************/
+uint8 CLuaBaseEntity::getOffhandHitCount()
+{
+    XI_DEBUG_BREAK_IF(m_PBaseEntity->objtype == TYPE_NPC);
+
+    return static_cast<CBattleEntity*>(m_PBaseEntity)->GetSubWeaponHitCount();
+}
+
+/************************************************************************
  *  Function: removeAmmo()
  *  Purpose : Expends one item in the ammo slot (arrow,bullet, etc)
  *  Example : player:removeAmmo()
@@ -13001,6 +13027,8 @@ int32 CLuaBaseEntity::takeWeaponskillDamage(CLuaBaseEntity* attacker, int32 dama
     auto*       PChar      = static_cast<CCharEntity*>(attacker->m_PBaseEntity);
     ATTACK_TYPE attackType = static_cast<ATTACK_TYPE>(atkType);
     DAMAGE_TYPE damageType = static_cast<DAMAGE_TYPE>(dmgType);
+
+    printf("TPMult = %f, BonusTP = %i\n", tpMultiplier, bonusTP );
 
     return battleutils::TakeWeaponskillDamage(PChar, static_cast<CBattleEntity*>(m_PBaseEntity), damage, attackType, damageType, slot,
                                               primary, tpMultiplier, bonusTP, targetTPMultiplier, isMagicWS);
@@ -17368,6 +17396,8 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getRangedDmg", CLuaBaseEntity::getRangedDmg);
     SOL_REGISTER("getRangedDmgRank", CLuaBaseEntity::getRangedDmgRank);
     SOL_REGISTER("getAmmoDmg", CLuaBaseEntity::getAmmoDmg);
+    SOL_REGISTER("getWeaponHitCount", CLuaBaseEntity::getWeaponHitCount);
+    SOL_REGISTER("getOffhandHitCount", CLuaBaseEntity::getOffhandHitCount);
 
     SOL_REGISTER("removeAmmo", CLuaBaseEntity::removeAmmo);
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -716,7 +716,7 @@ public:
     auto   getWSSkillchainProp() -> std::tuple<uint8, uint8, uint8>; // returns weapon skill's skillchain properties (up to 3)
 
     int32 takeWeaponskillDamage(CLuaBaseEntity* attacker, int32 damage, uint8 atkType, uint8 dmgType, uint8 slot, bool primary,
-                                float tpMultiplier, uint16 bonusTP, float targetTPMultiplier, bool isMagicWS = false);
+                                float tpMultiplier, uint16 bonusTP, float targetTPMultiplier, bool isMagicWS = false, bool isJump = false);
 
     int32 takeSpellDamage(CLuaBaseEntity* caster, CLuaSpell* spell, int32 damage, uint8 atkType, uint8 dmgType);
     int32 takeSwipeLungeDamage(CLuaBaseEntity* caster, int32 damage, uint8 atkType, uint8 dmgType);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -704,6 +704,8 @@ public:
     uint16 getRangedDmg();                                                                                                                  // Get ranged weapon DMG rating
     uint16 getRangedDmgRank();                                                                                                              // Get ranged weapond DMG rating used for calculating rank
     uint16 getAmmoDmg();                                                                                                                    // Get ammo DMG rating
+    uint8  getWeaponHitCount();                                                                                                             // Gets a number of attacks between 1 and maxAttacks for the MainHand weapon (for OAX)
+    uint8  getOffhandHitCount();                                                                                                            // Gets a number of attacks between 1 and maxAttacks for the OffHand weapon (for OAX)
 
     void removeAmmo();
 

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -167,7 +167,7 @@ namespace battleutils
                              uint8 slot, uint16 tpMultiplier, CBattleEntity* taChar, bool giveTPtoVictim, bool giveTPtoAttacker, bool isCounter = false,
                              bool isCovered = false, CBattleEntity* POriginalTarget = nullptr);
     int32 TakeWeaponskillDamage(CCharEntity* PAttacker, CBattleEntity* PDefender, int32 damage, ATTACK_TYPE attackType, DAMAGE_TYPE damageType, uint8 slot,
-                                bool primary, float tpMultiplier, uint16 bonusTP, float targetTPMultiplier, bool isMagicWS = false);
+                                bool primary, float tpMultiplier, uint16 bonusTP, float targetTPMultiplier, bool isMagicWS = false, bool isJump = false);
     int32 TakeSkillchainDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 lastSkillDamage, CBattleEntity* taChar);
     int32 TakeSpellDamage(CBattleEntity* PDefender, CCharEntity* PAttacker, CSpell* PSpell, int32 damage, ATTACK_TYPE attackType, DAMAGE_TYPE damageType);
     int32 TakeSwipeLungeDamage(CBattleEntity* PDefender, CCharEntity* PAttacker, int32 damage, ATTACK_TYPE attackType, DAMAGE_TYPE damageType);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->

**_I affirm:_**

- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I have read and understood the [Contributing Guide](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/AirSkyBoat/AirSkyBoat/blob/staging/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## Please enter a player-facing description

<!-- Example: Adjusted the damage limits on physical weaponskills (Shozokui) -->
* Fixed WS calculation for Jump type abilities to take "Occasionally Attacks X" weapons into account. (Both MainHand and OffHand)
* Fixed Jump TP calculation when multi-hits occur.
* Made it so Jump abilities will no longer give TP to the target. (This is how retail functions)

## What does this pull request do? (Please be technical)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
* WS can now utilize a new parameter "canUseOccAtkX". Currently this is only needed for Jump abilities, but I went with a more flexible approach in case a use case arises where a WS or Ability that utilizes WS DMG calcs like Jump need to respect OAX Weapons.
* I've exposed the GetHitCount method of CItemWeapon through the BattleEntity so that it can now be called from Lua. 
* Previously the Jump multi-hit TP calculation was incorrectly changing the tpMultiplier which could result in higher than expected values. I've changed it to instead collate the total hits into tpHitsLanded.
*  The last major change was adding a new argument to the takeWeaponskillDamage methods that is just a boolean for whether the WS was a Jump ability. This is necessary because Jumps do not actually give TP to defenders on retail, so a check has been added to avoid that happening.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here. -->
The easiest way to test these changes is to make your GM character a WAR/DRG and equip a Ridill. (Avoid using Store TP Gear)
You should then be able to use Jump and High Jump on a mob and observe your TP gain. I believe for Ridill's delay, the base gain from 1 hit is 63, but you can figure it out by either waiting for a single auto-attack, or switch to a Hofud and observe the TP gain to get your base.
You should see 63 TP * the number of OAX hits for that activation. (DA/TA/ETC can increase this and will only activate for the 1st main hit)

If you want some fun, switch to NIN/DRG and equip Kraken Club and Merc. Kris. This helps validate the behavior with Dual Wield.

## Special Deployment Considerations

<!-- Include any steps that need to be taken when deploying to the live environment. -->
<!-- Example: Need to run one_time_sql_conversion.sql -->

There shouldn't be any special considerations.